### PR TITLE
refactor: properly support different forward modes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ mod util;
 
 pub use {
     auth::{AcceptAll, AuthError, AuthHandler, DenyAll},
-    gateway::{ExtractDestination, ResolveDestination, gateway_accept_loop},
+    gateway::{
+        Destination, ExtractDestination, ForwardMode, ResolveDestination, gateway_accept_loop,
+    },
     http_connect::{
         ALPN, IROH_DESTINATION_HEADER, PoolOptions, TunnelClientPool, TunnelClientStreams,
         TunnelListener,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -88,7 +88,7 @@ pub struct HttpRequest {
 
 #[derive(Debug, Clone)]
 pub struct InitialData {
-    data: Bytes,
+    pub(crate) data: Bytes,
     body_offset: usize,
 }
 
@@ -98,6 +98,9 @@ impl InitialData {
             data: buf.freeze(),
             body_offset: offset,
         }
+    }
+    pub fn len(&self) -> usize {
+        self.data.len()
     }
     pub fn full(self) -> Bytes {
         self.data


### PR DESCRIPTION
The previous refactor inadvertently removed support for the mode where a gateway *injects* a remote authority (like when extracting a codename from regular HTTP request's subdomain, and using that to fetch a ticket with endpoint id and upstream authority). It only supported the modes where the gateway receives a HTTP proxy or CONNECT request.

This restores that mode, while keeping the others as well.