### PR TITLE
feat: downstream metrics and avoid dropping conns prematurely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1830,6 +1830,7 @@ dependencies = [
  "n0-error",
  "n0-future",
  "n0-tracing-test",
+ "pin-project",
  "reqwest",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ iroh-blobs = "0.97.0"
 iroh-metrics = "0.38.2"
 n0-error = "0.1.3"
 n0-future = "0.3.2"
+pin-project = "1.1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2"] }
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-util = { version = "0.7.16", features = ["time"] }

--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -23,7 +23,7 @@ use tokio::{
     io::{AsyncRead, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},
 };
-use tokio_util::sync::CancellationToken;
+use tokio_util::{io::ReaderStream, sync::CancellationToken};
 use tracing::{Instrument, debug, error_span, warn};
 
 pub use self::opts::{
@@ -35,7 +35,7 @@ use crate::{
     parse::{HttpRequest, HttpResponse},
     util::{
         Prebufferable, Prebuffered, StreamEvent, TrackedRead, TrackedStream, TrackedWrite,
-        forward_bidi, nores, recv_to_stream,
+        forward_bidi, nores,
     },
 };
 
@@ -114,14 +114,14 @@ impl DownstreamProxy {
         &self,
         destination: &EndpointAuthority,
     ) -> Result<TunnelClientStreams, ProxyError> {
-        let mut conn = self
+        let (conn, mut send, recv) = self
             .connect(destination.endpoint_id)
             .await
             .map_err(ProxyError::gateway_timeout)?;
-        conn.send
-            .write_all(destination.authority.to_connect_request().as_bytes())
+        send.write_all(destination.authority.to_connect_request().as_bytes())
             .await?;
-        let response = HttpResponse::read(&mut conn.recv)
+        let mut recv = Prebuffered::new(recv, HEADER_SECTION_MAX_LENGTH);
+        let response = HttpResponse::read(&mut recv)
             .await
             .map_err(ProxyError::bad_gateway)?;
         debug!(status=%response.status, "response from upstream");
@@ -131,7 +131,7 @@ impl DownstreamProxy {
                 anyerr!("Upstream gateway returned error response"),
             ))
         } else {
-            Ok(conn)
+            Ok(TunnelClientStreams { send, recv, conn })
         }
     }
 
@@ -265,7 +265,10 @@ impl DownstreamProxy {
         }
     }
 
-    async fn connect(&self, destination: EndpointId) -> Result<TunnelClientStreams, ProxyError> {
+    async fn connect(
+        &self,
+        destination: EndpointId,
+    ) -> Result<(ConnectionRef, SendStream, RecvStream), ProxyError> {
         let conn = self
             .pool
             .get_or_connect(destination)
@@ -275,8 +278,7 @@ impl DownstreamProxy {
             .open_bi()
             .await
             .map_err(|err| ProxyError::bad_gateway(anyerr!(err)))?;
-        let recv = Prebuffered::new(recv, HEADER_SECTION_MAX_LENGTH);
-        Ok(TunnelClientStreams { send, recv, conn })
+        Ok((conn, send, recv))
     }
 
     async fn handle_hyper_request(
@@ -341,15 +343,22 @@ impl DownstreamProxy {
         debug!(destination=%destination.fmt_short(), ?request, is_connect, is_h2_extended_connect, is_upgrade, "pipe request to upstream");
 
         // Connect to upstream.
-        let conn = self.connect(destination).await?;
-        debug!(endpoint_id=%conn.conn.remote_id().fmt_short(), "connected to upstream");
+        let (conn, send, recv) = self.connect(destination).await?;
+        debug!(endpoint_id=%conn.remote_id().fmt_short(), "connected to upstream");
 
-        let TunnelClientStreams { send, recv, conn } = conn;
         let conn_guard = Arc::new(conn);
         let mut upstream_send = TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream))
             .with_guard(conn_guard.clone());
-        let mut upstream_recv = TrackedRead::new(recv, inc_by_delta!(metrics, bytes_from_upstream))
-            .with_guard(conn_guard.clone());
+        let upstream_recv = TrackedRead::new(recv, {
+            let metrics = metrics.clone();
+            move |d| {
+                println!("!! upstream recv: {d}");
+                metrics.bytes_from_upstream.inc_by(d);
+            }
+        })
+        // let mut upstream_recv = TrackedRead::new(recv, inc_by_delta!(metrics, bytes_from_upstream))
+        .with_guard(conn_guard.clone());
+        let mut upstream_recv = Prebuffered::new(upstream_recv, HEADER_SECTION_MAX_LENGTH);
 
         // Send request headers.
         request.write(&mut upstream_send).await?;
@@ -372,16 +381,15 @@ impl DownstreamProxy {
                     upgrade_fut,
                     upstream_recv,
                     upstream_send,
-                    metrics.clone(),
                 ));
-                response_to_hyper(response, None, metrics, Some(conn_guard))?
+                response_to_hyper::<tokio::io::Empty>(response, None, metrics)?
             } else if request.method == Method::CONNECT {
-                response_to_hyper(response, None, metrics, Some(conn_guard))?
+                response_to_hyper::<tokio::io::Empty>(response, None, metrics)?
             } else {
                 spawn(forward_hyper_body_and_finish(body, upstream_send));
-                // response_to_hyper tracks metrics directly.
-                let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
-                response_to_hyper(response, Some(upstream_recv), metrics, Some(conn_guard))?
+                // // response_to_hyper tracks metrics directly.
+                // let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
+                response_to_hyper(response, Some(upstream_recv), metrics)?
             }
         } else {
             spawn(forward_hyper_body_and_finish(body, upstream_send));
@@ -396,9 +404,9 @@ impl DownstreamProxy {
                 status = %response.status,
                 "received response header from upstream"
             );
-            // response_to_hyper tracks metrics directly.
-            let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
-            response_to_hyper(response, Some(upstream_recv), metrics, Some(conn_guard))?
+            // // response_to_hyper tracks metrics directly.
+            // let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
+            response_to_hyper(response, Some(upstream_recv), metrics)?
         };
 
         Ok(response)
@@ -563,20 +571,28 @@ impl ProxyError {
 
 type HyperBody = BoxBody<Bytes, io::Error>;
 
-fn response_to_hyper<G: Unpin + Send + Sync + 'static>(
+fn response_to_hyper<R>(
     response: HttpResponse,
-    body: Option<Prebuffered<RecvStream>>,
+    body: Option<R>,
     metrics: Arc<DownstreamMetrics>,
-    guard: Option<G>,
-) -> Result<Response<HyperBody>, ProxyError> {
+) -> Result<Response<HyperBody>, ProxyError>
+where
+    R: AsyncRead + Send + Sync + Unpin + 'static,
+{
     let mut builder = Response::builder().status(response.status);
     let headers = builder.headers_mut().unwrap();
     *headers = response.headers;
     let body = match body {
         Some(body) => {
-            let stream = recv_to_stream(body);
-            let stream = TrackedStream::with_guard(stream, guard, move |ev| match ev {
-                StreamEvent::Data(n) => nores(metrics.bytes_from_upstream.inc_by(n)),
+            let stream = ReaderStream::new(body);
+            // let stream = recv_to_stream(body);
+            // let stream = TrackedStream::with_guard(stream, guard, move |ev| match ev {
+            //     StreamEvent::Data(_n) => {}
+            //     StreamEvent::Done(Ok(())) => nores(metrics.requests_completed.inc()),
+            //     StreamEvent::Done(Err(_)) => nores(metrics.requests_failed.inc()),
+            // });
+            let stream = TrackedStream::new(stream, move |ev| match ev {
+                StreamEvent::Data(_n) => {}
                 StreamEvent::Done(Ok(())) => nores(metrics.requests_completed.inc()),
                 StreamEvent::Done(Err(_)) => nores(metrics.requests_failed.inc()),
             });
@@ -621,18 +637,11 @@ async fn forward_hyper_upgrade(
     upgrade_fut: hyper::upgrade::OnUpgrade,
     mut upstream_recv: impl AsyncRead + Send + Unpin,
     mut upstream_send: impl AsyncWrite + Send + Unpin,
-    metrics: Arc<DownstreamMetrics>,
 ) -> Result<()> {
     let upgraded = upgrade_fut.await.std_context("HTTP/1 upgrade failed")?;
     let upgraded = TokioIo::new(upgraded);
     // Split the upgraded connection for bidirectional copy
-    let (client_read, client_write) = tokio::io::split(upgraded);
-
-    let mut client_read = TrackedRead::new(client_read, inc_by_delta!(metrics, bytes_to_upstream));
-    let mut client_write = TrackedWrite::new(client_write, {
-        inc_by_delta!(metrics, bytes_from_upstream)
-    });
-
+    let (mut client_read, mut client_write) = tokio::io::split(upgraded);
     forward_bidi(
         &mut client_read,
         &mut client_write,

--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -36,6 +36,7 @@ use crate::{
     util::{Prebuffered, forward_bidi, recv_to_stream},
 };
 
+pub(crate) mod metrics;
 pub(crate) mod opts;
 
 /// Proxy that accepts TCP connections and forwards them over iroh.

--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -33,7 +33,10 @@ pub use self::opts::{
 use crate::{
     ALPN, Authority, HEADER_SECTION_MAX_LENGTH, inc_by_delta,
     parse::{HttpRequest, HttpResponse},
-    util::{Prebuffered, TrackedRead, TrackedWrite, forward_bidi, recv_to_stream},
+    util::{
+        Prebufferable, Prebuffered, StreamEvent, TrackedRead, TrackedStream, TrackedWrite,
+        forward_bidi, nores, recv_to_stream,
+    },
 };
 
 pub(crate) mod metrics;
@@ -208,25 +211,17 @@ impl DownstreamProxy {
                 self.metrics.requests_accepted.inc();
                 self.metrics.requests_accepted_tcp.inc();
                 let (tcp_recv, tcp_send) = stream.split();
-                let TunnelClientStreams {
-                    send: mut upstream_send,
-                    recv: mut upstream_recv,
-                    conn: connection_ref,
-                } = self.create_tunnel(destination).await?;
-                debug!(endpoint_id=%connection_ref.remote_id().fmt_short(), "tunnel established");
+                let mut conn = self.create_tunnel(destination).await?;
+                debug!(endpoint_id=%conn.conn.remote_id().fmt_short(), "tunnel established");
                 let metrics = self.metrics.clone();
-                let mut downstream_recv =
+                let mut tcp_recv =
                     TrackedRead::new(tcp_recv, inc_by_delta!(metrics, bytes_to_upstream));
-                let mut downstream_send =
+                let mut tcp_send =
                     TrackedWrite::new(tcp_send, inc_by_delta!(metrics, bytes_from_upstream));
-                let res = forward_bidi(
-                    &mut downstream_recv,
-                    &mut downstream_send,
-                    &mut upstream_recv,
-                    &mut upstream_send,
-                )
-                .await
-                .map_err(ProxyError::io);
+                let res =
+                    forward_bidi(&mut tcp_recv, &mut tcp_send, &mut conn.recv, &mut conn.send)
+                        .await
+                        .map_err(ProxyError::io);
                 match res {
                     Ok(_) => {
                         self.metrics.requests_completed.inc();
@@ -306,7 +301,6 @@ impl DownstreamProxy {
         let mut request = HttpRequest::from_parts(parts);
 
         let metrics = self.metrics.clone();
-        let mut tracker = RequestTracker::new(metrics.clone());
 
         let destination = match opts
             .request_handler
@@ -316,11 +310,11 @@ impl DownstreamProxy {
             Ok(destination) => destination,
             Err(deny) => {
                 metrics.requests_denied.inc();
-                tracker.deny();
                 return Err(ProxyError::from(deny));
             }
         };
 
+        // track metrics.
         metrics.requests_accepted.inc();
         if original_version == Version::HTTP_2 {
             metrics.requests_accepted_h2.inc();
@@ -347,23 +341,21 @@ impl DownstreamProxy {
         debug!(destination=%destination.fmt_short(), ?request, is_connect, is_h2_extended_connect, is_upgrade, "pipe request to upstream");
 
         // Connect to upstream.
-        let TunnelClientStreams {
-            send,
-            mut recv,
-            conn,
-        } = self.connect(destination).await?;
-        debug!(endpoint_id=%conn.remote_id().fmt_short(), "connected to upstream");
+        let conn = self.connect(destination).await?;
+        debug!(endpoint_id=%conn.conn.remote_id().fmt_short(), "connected to upstream");
 
-        let mut send = send;
-        {
-            let mut header_tracker =
-                TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
-            request.write(&mut header_tracker).await?;
-            send = header_tracker.into_inner();
-        }
+        let TunnelClientStreams { send, recv, conn } = conn;
+        let conn_guard = Arc::new(conn);
+        let mut upstream_send = TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream))
+            .with_guard(conn_guard.clone());
+        let mut upstream_recv = TrackedRead::new(recv, inc_by_delta!(metrics, bytes_from_upstream))
+            .with_guard(conn_guard.clone());
+
+        // Send request headers.
+        request.write(&mut upstream_send).await?;
 
         let response = if let Some(upgrade_fut) = upgrade {
-            let mut response = read_response(&mut recv).await?;
+            let mut response = read_response(&mut upstream_recv).await?;
             debug!(?response, "read connect response");
 
             if is_h2_extended_connect && response.status == StatusCode::SWITCHING_PROTOCOLS {
@@ -376,70 +368,40 @@ impl DownstreamProxy {
                 || is_upgrade && response.status == StatusCode::SWITCHING_PROTOCOLS;
 
             if is_ok {
-                let streams = TunnelClientStreams { send, recv, conn };
-                let metrics_clone = metrics.clone();
-                spawn(forward_hyper_upgrade(upgrade_fut, streams, metrics_clone));
-                response_to_hyper(response, None, &metrics)?
+                spawn(forward_hyper_upgrade(
+                    upgrade_fut,
+                    upstream_recv,
+                    upstream_send,
+                    metrics.clone(),
+                ));
+                response_to_hyper(response, None, metrics, Some(conn_guard))?
             } else if request.method == Method::CONNECT {
-                response_to_hyper(response, None, &metrics)?
+                response_to_hyper(response, None, metrics, Some(conn_guard))?
             } else {
-                let tracked_send =
-                    TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
-                spawn(forward_hyper_body_and_finish(body, tracked_send));
-                response_to_hyper(response, Some(recv), &metrics)?
+                spawn(forward_hyper_body_and_finish(body, upstream_send));
+                // response_to_hyper tracks metrics directly.
+                let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
+                response_to_hyper(response, Some(upstream_recv), metrics, Some(conn_guard))?
             }
         } else {
-            let tracked_send = TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
-            spawn(forward_hyper_body_and_finish(body, tracked_send));
-            let response = read_response(&mut recv).await?;
+            spawn(forward_hyper_body_and_finish(body, upstream_send));
+            let response = match read_response(&mut upstream_recv).await {
+                Ok(response) => response,
+                Err(err) => {
+                    metrics.requests_failed.inc();
+                    return Err(err.into());
+                }
+            };
             debug!(
                 status = %response.status,
                 "received response header from upstream"
             );
-            response_to_hyper(response, Some(recv), &metrics)?
+            // response_to_hyper tracks metrics directly.
+            let (upstream_recv, _metrics_inc) = upstream_recv.into_parts();
+            response_to_hyper(response, Some(upstream_recv), metrics, Some(conn_guard))?
         };
 
-        tracker.complete();
         Ok(response)
-    }
-}
-
-enum RequestState {
-    Pending,
-    Completed,
-    Denied,
-}
-
-struct RequestTracker {
-    metrics: Arc<DownstreamMetrics>,
-    state: RequestState,
-}
-
-impl RequestTracker {
-    fn new(metrics: Arc<DownstreamMetrics>) -> Self {
-        Self {
-            metrics,
-            state: RequestState::Pending,
-        }
-    }
-
-    fn complete(&mut self) {
-        if matches!(self.state, RequestState::Pending) {
-            self.metrics.requests_completed.inc();
-            self.state = RequestState::Completed;
-        }
-    }
-
-    fn deny(&mut self) {
-        self.state = RequestState::Denied;
-    }
-}
-
-impl Drop for RequestTracker {
-    fn drop(&mut self) {
-        if matches!(self.state, RequestState::Pending) {
-            self.metrics.requests_failed.inc();
-        }
     }
 }
 
@@ -601,19 +563,25 @@ impl ProxyError {
 
 type HyperBody = BoxBody<Bytes, io::Error>;
 
-fn response_to_hyper(
+fn response_to_hyper<G: Unpin + Send + Sync + 'static>(
     response: HttpResponse,
     body: Option<Prebuffered<RecvStream>>,
-    metrics: &Arc<DownstreamMetrics>,
+    metrics: Arc<DownstreamMetrics>,
+    guard: Option<G>,
 ) -> Result<Response<HyperBody>, ProxyError> {
     let mut builder = Response::builder().status(response.status);
     let headers = builder.headers_mut().unwrap();
     *headers = response.headers;
     let body = match body {
-        Some(body) => StreamBody::new(
-            recv_to_stream(body, inc_by_delta!(metrics, bytes_from_upstream)).map_ok(Frame::data),
-        )
-        .boxed(),
+        Some(body) => {
+            let stream = recv_to_stream(body);
+            let stream = TrackedStream::with_guard(stream, guard, move |ev| match ev {
+                StreamEvent::Data(n) => nores(metrics.bytes_from_upstream.inc_by(n)),
+                StreamEvent::Done(Ok(())) => nores(metrics.requests_completed.inc()),
+                StreamEvent::Done(Err(_)) => nores(metrics.requests_failed.inc()),
+            });
+            StreamBody::new(stream.map_ok(Frame::data)).boxed()
+        }
         None => Empty::new().map_err(infallible_to_io).boxed(),
     };
     builder
@@ -621,9 +589,9 @@ fn response_to_hyper(
         .map_err(|err| ProxyError::bad_gateway(anyerr!(err)))
 }
 
-async fn forward_hyper_body_and_finish<F>(
+async fn forward_hyper_body_and_finish<F, G: Unpin>(
     body: Incoming,
-    mut send: TrackedWrite<SendStream, F>,
+    mut send: TrackedWrite<SendStream, F, G>,
 ) -> Result<()>
 where
     F: Fn(u64) + Unpin + Send + 'static,
@@ -651,38 +619,31 @@ async fn forward_hyper_body(
 
 async fn forward_hyper_upgrade(
     upgrade_fut: hyper::upgrade::OnUpgrade,
-    conn: TunnelClientStreams,
+    mut upstream_recv: impl AsyncRead + Send + Unpin,
+    mut upstream_send: impl AsyncWrite + Send + Unpin,
     metrics: Arc<DownstreamMetrics>,
 ) -> Result<()> {
     let upgraded = upgrade_fut.await.std_context("HTTP/1 upgrade failed")?;
     let upgraded = TokioIo::new(upgraded);
     // Split the upgraded connection for bidirectional copy
     let (client_read, client_write) = tokio::io::split(upgraded);
-    let TunnelClientStreams {
-        send: mut upstream_send,
-        recv: mut upstream_recv,
-        conn: conn_ref,
-    } = conn;
 
-    let mut downstream_read =
-        TrackedRead::new(client_read, inc_by_delta!(metrics, bytes_to_upstream));
-    let mut downstream_write = TrackedWrite::new(client_write, {
+    let mut client_read = TrackedRead::new(client_read, inc_by_delta!(metrics, bytes_to_upstream));
+    let mut client_write = TrackedWrite::new(client_write, {
         inc_by_delta!(metrics, bytes_from_upstream)
     });
 
     forward_bidi(
-        &mut downstream_read,
-        &mut downstream_write,
+        &mut client_read,
+        &mut client_write,
         &mut upstream_recv,
         &mut upstream_send,
     )
     .await?;
-
-    drop(conn_ref);
     Ok(())
 }
 
-async fn read_response(recv: &mut Prebuffered<RecvStream>) -> Result<HttpResponse, ProxyError> {
+async fn read_response(recv: &mut impl Prebufferable) -> Result<HttpResponse, ProxyError> {
     HttpResponse::read(recv)
         .await
         .map_err(ProxyError::bad_gateway)

--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, fmt::Debug, io, net::SocketAddr};
+use std::{convert::Infallible, fmt::Debug, io, net::SocketAddr, sync::Arc};
 
 use bytes::Bytes;
 use http::{Method, StatusCode, Version, header};
@@ -14,13 +14,13 @@ use hyper_util::{
 };
 use iroh::{
     Endpoint, EndpointId,
-    endpoint::{RecvStream, SendStream},
+    endpoint::{ConnectionError, RecvStream, SendStream},
 };
-use iroh_blobs::util::connection_pool::{ConnectionPool, ConnectionRef};
+use iroh_blobs::util::connection_pool::{self, ConnectionPool, ConnectionRef};
 use n0_error::{AnyError, Result, StdResultExt, anyerr, stack_error};
 use n0_future::TryStreamExt;
 use tokio::{
-    io::{AsyncRead, AsyncWrite},
+    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},
 };
 use tokio_util::sync::CancellationToken;
@@ -31,12 +31,13 @@ pub use self::opts::{
     StaticForwardProxy, StaticReverseProxy,
 };
 use crate::{
-    ALPN, Authority, HEADER_SECTION_MAX_LENGTH,
+    ALPN, Authority, HEADER_SECTION_MAX_LENGTH, inc_by_delta,
     parse::{HttpRequest, HttpResponse},
-    util::{Prebuffered, forward_bidi, recv_to_stream},
+    util::{Prebuffered, TrackedRead, TrackedWrite, forward_bidi, recv_to_stream},
 };
 
 pub(crate) mod metrics;
+pub use self::metrics::DownstreamMetrics;
 pub(crate) mod opts;
 
 /// Proxy that accepts TCP connections and forwards them over iroh.
@@ -58,13 +59,49 @@ pub(crate) mod opts;
 #[derive(Clone, Debug)]
 pub struct DownstreamProxy {
     pool: ConnectionPool,
+    metrics: Arc<DownstreamMetrics>,
 }
 
 impl DownstreamProxy {
     /// Creates a downstream proxy with the given endpoint and pool options.
-    pub fn new(endpoint: Endpoint, opts: PoolOpts) -> Self {
-        let pool = ConnectionPool::new(endpoint, ALPN, opts.into());
-        Self { pool }
+    pub fn new(endpoint: Endpoint, pool_opts: PoolOpts) -> Self {
+        let metrics = Arc::new(DownstreamMetrics::default());
+        let opts: connection_pool::Options = pool_opts.into();
+
+        // Track connection open/close metrics.
+        let pool_opts = opts.with_on_connected({
+            let metrics = metrics.clone();
+            // This conn clone is *not* protected by a pool guard, so by awaiting its close method
+            // we don't keep the connection alive post-idle.
+            move |_endpoint, unguarded_conn| {
+                let metrics = metrics.clone();
+                async move {
+                    metrics.iroh_connections_opened.inc();
+                    let metrics = metrics.clone();
+                    tokio::spawn(async move {
+                        let reason = unguarded_conn.closed().await;
+                        match reason {
+                            ConnectionError::LocallyClosed => {
+                                metrics.iroh_connections_closed_idle.inc();
+                            }
+                            // It's always us that closes connections gracefully.
+                            _ => {
+                                metrics.iroh_connections_closed_error.inc();
+                            }
+                        }
+                    });
+                    Ok(())
+                }
+            }
+        });
+
+        let pool = ConnectionPool::new(endpoint, ALPN, pool_opts);
+        Self { pool, metrics }
+    }
+
+    /// Returns the downstream metrics tracker.
+    pub fn metrics(&self) -> &Arc<DownstreamMetrics> {
+        &self.metrics
     }
 
     /// Opens a CONNECT tunnel to the upstream proxy and returns the client streams.
@@ -168,13 +205,38 @@ impl DownstreamProxy {
     ) -> Result<()> {
         match mode {
             ProxyMode::Tcp(destination) => {
-                let (mut tcp_recv, mut tcp_send) = stream.split();
-                let mut conn = self.create_tunnel(destination).await?;
-                debug!(endpoint_id=%conn.conn.remote_id().fmt_short(), "tunnel established");
-                forward_bidi(&mut tcp_recv, &mut tcp_send, &mut conn.recv, &mut conn.send)
-                    .await
-                    .map_err(ProxyError::io)?;
-                Ok(())
+                self.metrics.requests_accepted.inc();
+                self.metrics.requests_accepted_tcp.inc();
+                let (tcp_recv, tcp_send) = stream.split();
+                let TunnelClientStreams {
+                    send: mut upstream_send,
+                    recv: mut upstream_recv,
+                    conn: connection_ref,
+                } = self.create_tunnel(destination).await?;
+                debug!(endpoint_id=%connection_ref.remote_id().fmt_short(), "tunnel established");
+                let metrics = self.metrics.clone();
+                let mut downstream_recv =
+                    TrackedRead::new(tcp_recv, inc_by_delta!(metrics, bytes_to_upstream));
+                let mut downstream_send =
+                    TrackedWrite::new(tcp_send, inc_by_delta!(metrics, bytes_from_upstream));
+                let res = forward_bidi(
+                    &mut downstream_recv,
+                    &mut downstream_send,
+                    &mut upstream_recv,
+                    &mut upstream_send,
+                )
+                .await
+                .map_err(ProxyError::io);
+                match res {
+                    Ok(_) => {
+                        self.metrics.requests_completed.inc();
+                        Ok(())
+                    }
+                    Err(err) => {
+                        self.metrics.requests_failed.inc();
+                        Err(err.into())
+                    }
+                }
             }
             ProxyMode::Http(opts) => {
                 let io = TokioIo::new(stream);
@@ -230,6 +292,7 @@ impl DownstreamProxy {
     ) -> Result<Response<HyperBody>, ProxyError> {
         debug!(?request, "incoming");
 
+        let original_version = request.version();
         let is_upgrade = request.headers().contains_key(header::UPGRADE);
         let is_connect = request.method() == Method::CONNECT;
         let is_h2_extended_connect = convert_h2_extended_connect_to_upgrade(&mut request);
@@ -242,28 +305,65 @@ impl DownstreamProxy {
         let (parts, body) = request.into_parts();
         let mut request = HttpRequest::from_parts(parts);
 
-        let destination = opts
+        let metrics = self.metrics.clone();
+        let mut tracker = RequestTracker::new(metrics.clone());
+
+        let destination = match opts
             .request_handler
             .handle_request(src_addr, &mut request)
-            .await?;
+            .await
+        {
+            Ok(destination) => destination,
+            Err(deny) => {
+                metrics.requests_denied.inc();
+                tracker.deny();
+                return Err(ProxyError::from(deny));
+            }
+        };
+
+        metrics.requests_accepted.inc();
+        if original_version == Version::HTTP_2 {
+            metrics.requests_accepted_h2.inc();
+            if is_connect {
+                if is_h2_extended_connect {
+                    metrics.requests_accepted_h2_extended_connect.inc();
+                } else {
+                    metrics.requests_accepted_h2_connect.inc();
+                }
+            }
+        } else {
+            metrics.requests_accepted_h1.inc();
+            if is_connect {
+                metrics.requests_accepted_h1_connect.inc();
+            }
+            if is_upgrade {
+                metrics.requests_accepted_h1_upgrade.inc();
+            }
+        }
 
         // We always forward as HTTP/1.1.
         request.version = Version::HTTP_11;
 
-        // Now we shouldn't mutate the request anymore.
-        let request = request;
-
         debug!(destination=%destination.fmt_short(), ?request, is_connect, is_h2_extended_connect, is_upgrade, "pipe request to upstream");
 
         // Connect to upstream.
-        let mut conn = self.connect(destination).await?;
-        debug!("connected to upstream");
+        let TunnelClientStreams {
+            send,
+            mut recv,
+            conn,
+        } = self.connect(destination).await?;
+        debug!(endpoint_id=%conn.remote_id().fmt_short(), "connected to upstream");
 
-        // Forward the request header section.
-        request.write(&mut conn.send).await?;
+        let mut send = send;
+        {
+            let mut header_tracker =
+                TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
+            request.write(&mut header_tracker).await?;
+            send = header_tracker.into_inner();
+        }
 
-        if let Some(upgrade_fut) = upgrade {
-            let mut response = read_response(&mut conn.recv).await?;
+        let response = if let Some(upgrade_fut) = upgrade {
+            let mut response = read_response(&mut recv).await?;
             debug!(?response, "read connect response");
 
             if is_h2_extended_connect && response.status == StatusCode::SWITCHING_PROTOCOLS {
@@ -276,23 +376,69 @@ impl DownstreamProxy {
                 || is_upgrade && response.status == StatusCode::SWITCHING_PROTOCOLS;
 
             if is_ok {
-                spawn(forward_hyper_upgrade(upgrade_fut, conn));
-                response_to_hyper(response, None)
+                let streams = TunnelClientStreams { send, recv, conn };
+                let metrics_clone = metrics.clone();
+                spawn(forward_hyper_upgrade(upgrade_fut, streams, metrics_clone));
+                response_to_hyper(response, None, &metrics)?
             } else if request.method == Method::CONNECT {
-                response_to_hyper(response, None)
+                response_to_hyper(response, None, &metrics)?
             } else {
-                spawn(forward_hyper_body_and_finish(body, conn.send));
-                response_to_hyper(response, Some(conn.recv))
+                let tracked_send =
+                    TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
+                spawn(forward_hyper_body_and_finish(body, tracked_send));
+                response_to_hyper(response, Some(recv), &metrics)?
             }
         } else {
-            // For regular non-CONNECT requests, pipe body and read response concurrently.
-            spawn(forward_hyper_body_and_finish(body, conn.send));
-            let response = read_response(&mut conn.recv).await?;
+            let tracked_send = TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream));
+            spawn(forward_hyper_body_and_finish(body, tracked_send));
+            let response = read_response(&mut recv).await?;
             debug!(
                 status = %response.status,
                 "received response header from upstream"
             );
-            response_to_hyper(response, Some(conn.recv))
+            response_to_hyper(response, Some(recv), &metrics)?
+        };
+
+        tracker.complete();
+        Ok(response)
+    }
+}
+
+enum RequestState {
+    Pending,
+    Completed,
+    Denied,
+}
+
+struct RequestTracker {
+    metrics: Arc<DownstreamMetrics>,
+    state: RequestState,
+}
+
+impl RequestTracker {
+    fn new(metrics: Arc<DownstreamMetrics>) -> Self {
+        Self {
+            metrics,
+            state: RequestState::Pending,
+        }
+    }
+
+    fn complete(&mut self) {
+        if matches!(self.state, RequestState::Pending) {
+            self.metrics.requests_completed.inc();
+            self.state = RequestState::Completed;
+        }
+    }
+
+    fn deny(&mut self) {
+        self.state = RequestState::Denied;
+    }
+}
+
+impl Drop for RequestTracker {
+    fn drop(&mut self) {
+        if matches!(self.state, RequestState::Pending) {
+            self.metrics.requests_failed.inc();
         }
     }
 }
@@ -458,12 +604,16 @@ type HyperBody = BoxBody<Bytes, io::Error>;
 fn response_to_hyper(
     response: HttpResponse,
     body: Option<Prebuffered<RecvStream>>,
+    metrics: &Arc<DownstreamMetrics>,
 ) -> Result<Response<HyperBody>, ProxyError> {
     let mut builder = Response::builder().status(response.status);
     let headers = builder.headers_mut().unwrap();
     *headers = response.headers;
     let body = match body {
-        Some(body) => StreamBody::new(recv_to_stream(body, |_| {}).map_ok(Frame::data)).boxed(),
+        Some(body) => StreamBody::new(
+            recv_to_stream(body, inc_by_delta!(metrics, bytes_from_upstream)).map_ok(Frame::data),
+        )
+        .boxed(),
         None => Empty::new().map_err(infallible_to_io).boxed(),
     };
     builder
@@ -471,15 +621,24 @@ fn response_to_hyper(
         .map_err(|err| ProxyError::bad_gateway(anyerr!(err)))
 }
 
-async fn forward_hyper_body_and_finish(body: Incoming, mut send: SendStream) -> Result<()> {
+async fn forward_hyper_body_and_finish<F>(
+    body: Incoming,
+    mut send: TrackedWrite<SendStream, F>,
+) -> Result<()>
+where
+    F: Fn(u64) + Unpin + Send + 'static,
+{
     forward_hyper_body(body, &mut send).await?;
-    send.finish().anyerr()?;
+    send.into_inner().finish().anyerr()?;
     Ok(())
 }
 
 /// Forwards hyper body to send stream without finishing.
 /// Used for upgrade requests where we may need to continue using the stream.
-async fn forward_hyper_body(mut body: Incoming, send: &mut SendStream) -> Result<()> {
+async fn forward_hyper_body(
+    mut body: Incoming,
+    send: &mut (impl AsyncWrite + Unpin),
+) -> Result<()> {
     while let Some(frame) = body.frame().await {
         let frame = frame.anyerr()?;
         // TODO: Add support for trailers.
@@ -492,19 +651,34 @@ async fn forward_hyper_body(mut body: Incoming, send: &mut SendStream) -> Result
 
 async fn forward_hyper_upgrade(
     upgrade_fut: hyper::upgrade::OnUpgrade,
-    mut conn: TunnelClientStreams,
+    conn: TunnelClientStreams,
+    metrics: Arc<DownstreamMetrics>,
 ) -> Result<()> {
     let upgraded = upgrade_fut.await.std_context("HTTP/1 upgrade failed")?;
     let upgraded = TokioIo::new(upgraded);
     // Split the upgraded connection for bidirectional copy
-    let (mut client_read, mut client_write) = tokio::io::split(upgraded);
+    let (client_read, client_write) = tokio::io::split(upgraded);
+    let TunnelClientStreams {
+        send: mut upstream_send,
+        recv: mut upstream_recv,
+        conn: conn_ref,
+    } = conn;
+
+    let mut downstream_read =
+        TrackedRead::new(client_read, inc_by_delta!(metrics, bytes_to_upstream));
+    let mut downstream_write = TrackedWrite::new(client_write, {
+        inc_by_delta!(metrics, bytes_from_upstream)
+    });
+
     forward_bidi(
-        &mut client_read,
-        &mut client_write,
-        &mut conn.recv,
-        &mut conn.send,
+        &mut downstream_read,
+        &mut downstream_write,
+        &mut upstream_recv,
+        &mut upstream_send,
     )
     .await?;
+
+    drop(conn_ref);
     Ok(())
 }
 

--- a/src/downstream/metrics.rs
+++ b/src/downstream/metrics.rs
@@ -1,0 +1,70 @@
+use iroh_metrics::{Counter, MetricsGroup};
+
+#[derive(Debug, MetricsGroup)]
+#[non_exhaustive]
+#[metrics(name = "proxy-downstream", default)]
+pub struct DownstreamMetrics {
+    /// Total number of downstream requests that began processing (HTTP or TCP).
+    pub requests_accepted: Counter,
+
+    /// TCP-only requests (proxy is operating in `ProxyMode::Tcp`).
+    pub requests_accepted_tcp: Counter,
+    /// HTTP/1 requests that reached the downstream proxy.
+    pub requests_accepted_h1: Counter,
+    /// HTTP/2 requests that reached the downstream proxy.
+    pub requests_accepted_h2: Counter,
+
+    /// HTTP/1 CONNECT requests, i.e. e2e tunnels.
+    pub requests_accepted_h1_connect: Counter,
+    /// HTTP/1 upgrade requests (WebSocket, etc.) that were forwarded.
+    pub requests_accepted_h1_upgrade: Counter,
+
+    /// HTTP/2 CONNECT requests (excluding extended CONNECT), i.e. e2e tunnels.
+    pub requests_accepted_h2_connect: Counter,
+    /// HTTP/2 extended CONNECT requests (RFC 8441), i.e. WebSocket over HTTP/2.
+    pub requests_accepted_h2_extended_connect: Counter,
+
+    /// Requests rejected by the `RequestHandler` before opening an upstream tunnel.
+    pub requests_denied: Counter,
+    /// Requests that successfully finished and were proxied upstream.
+    pub requests_completed: Counter,
+    /// Requests that failed after being accepted (upstream or network error).
+    pub requests_failed: Counter,
+
+    /// Number of QUIC connections opened toward upstream iroh nodes.
+    pub iroh_connections_opened: Counter,
+    /// Connections that closed cleanly from the local side (pool dropped conn after idle timeout)
+    pub iroh_connections_closed_idle: Counter,
+    /// Connections that terminated with an error (timeouts, transport errors, resets).
+    pub iroh_connections_closed_error: Counter,
+
+    /// Bytes written to the upstream proxy (downstream ➜ upstream).
+    pub bytes_to_upstream: Counter,
+    /// Bytes read from the upstream proxy (upstream ➜ downstream).
+    pub bytes_from_upstream: Counter,
+}
+
+impl DownstreamMetrics {
+    /// Returns the number of requests currently in flight.
+    ///
+    /// Calculated as `accepted - completed - failed` using saturating arithmetic.
+    pub fn active_requests(&self) -> u64 {
+        self.requests_accepted
+            .get()
+            .saturating_sub(self.requests_completed.get())
+            .saturating_sub(self.requests_failed.get())
+    }
+
+    /// Returns the total number of opened QUIC connections.
+    pub fn total_iroh_connections(&self) -> u64 {
+        self.iroh_connections_opened.get()
+    }
+
+    /// Returns the estimated number of currently open QUIC connections.
+    pub fn active_iroh_connections(&self) -> u64 {
+        self.iroh_connections_opened
+            .get()
+            .saturating_sub(self.iroh_connections_closed_idle.get())
+            .saturating_sub(self.iroh_connections_closed_error.get())
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -8,7 +8,10 @@ use http::{
 use n0_error::{Result, StackResultExt, StdResultExt, anyerr, ensure_any};
 use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 
-use crate::{downstream::SrcAddr, util::Prebuffered};
+use crate::{
+    downstream::SrcAddr,
+    util::{Prebufferable, Prebuffered},
+};
 
 /// Hop-by-hop headers that MUST NOT be forwarded by proxies per RFC 9110 Section 7.6.1.
 const HOP_BY_HOP_HEADERS: &[HeaderName] = &[
@@ -636,7 +639,7 @@ impl HttpResponse {
     ///
     /// Does not remove the header section from `reader`.
     /// Returns [`io::ErrorKind::OutOfMemory`] if the header section exceeds the buffer limit.
-    pub async fn peek(reader: &mut Prebuffered<impl AsyncRead + Unpin>) -> Result<(usize, Self)> {
+    pub async fn peek(reader: &mut impl Prebufferable) -> Result<(usize, Self)> {
         while !reader.is_full() {
             reader.buffer_more().await?;
             if let Some(response) = Self::parse_with_len(reader.buffer())? {
@@ -654,7 +657,7 @@ impl HttpResponse {
     /// Reads and parses the response status line and header section.
     ///
     /// Removes the header section from the reader.
-    pub async fn read(reader: &mut Prebuffered<impl AsyncRead + Unpin>) -> Result<Self> {
+    pub async fn read(reader: &mut impl Prebufferable) -> Result<Self> {
         let (len, response) = Self::peek(reader).await?;
         reader.discard(len);
         Ok(response)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -659,6 +659,7 @@ impl HttpResponse {
     /// Removes the header section from the reader.
     pub async fn read(reader: &mut impl Prebufferable) -> Result<Self> {
         let (len, response) = Self::peek(reader).await?;
+        println!("READ RESPONSE form upsttream at downstream {len}");
         reader.discard(len);
         Ok(response)
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -188,7 +188,9 @@ async fn create_http_connect_tunnel(
 }
 
 /// Reads HTTP response and returns (status_code, body).
-async fn read_http_response(stream: &mut (impl AsyncRead + Unpin)) -> Result<(u16, Vec<u8>)> {
+async fn read_http_response(
+    stream: &mut (impl AsyncRead + Unpin + Send),
+) -> Result<(u16, Vec<u8>)> {
     let mut prebuf = Prebuffered::new(stream, 8192);
     let response = HttpResponse::read(&mut prebuf)
         .timeout(Duration::from_secs(3))
@@ -1746,8 +1748,10 @@ mod origin_server {
                     async move {
                         let method = req.method().clone();
                         let path = req.uri().path().to_string();
+                        println!("RECEIVED {path}");
                         let body_bytes = req.collect().await.unwrap().to_bytes();
                         let body_str = String::from_utf8_lossy(&body_bytes);
+                        println!("RECEIVED BODY {body_str}");
                         let response = format!("{} {} {}: {}", *label, method, path, body_str);
                         Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(response))))
                     }
@@ -1843,6 +1847,8 @@ mod origin_server {
 }
 
 mod metrics {
+    use bytes::Bytes;
+
     use super::*;
 
     struct RejectAll;
@@ -1858,8 +1864,9 @@ mod metrics {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn http_metrics_track_requests() -> Result {
-        let (origin_addr, origin_task) = spawn_origin_server("metrics-origin").await?;
+        let (origin_addr, origin_task) = spawn_origin_server_echo_body("origin").await?;
         let (upstream_router, upstream_id) = spawn_upstream_proxy().await?;
         let mode = ProxyMode::Http(HttpProxyOpts::new(StaticForwardProxy(upstream_id)));
         let (proxy_addr, _, metrics, proxy_task) =
@@ -1868,29 +1875,51 @@ mod metrics {
             .proxy(reqwest::Proxy::http(format!("http://{proxy_addr}")).anyerr()?)
             .build()
             .anyerr()?;
+        let (tx, rx) = tokio::sync::mpsc::channel::<std::io::Result<Bytes>>(1);
+        let body = reqwest::Body::wrap_stream(tokio_stream::wrappers::ReceiverStream::new(rx));
+
+        // we spawn a separate task to ensure active_requests is 1 if the body is not yet terminated.
+        // need to do this in a task to not deadlock, because post.send().await waits for the response.
+        let body_task = tokio::task::spawn({
+            let metrics = metrics.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                tx.send(Ok(Bytes::from("hello"))).await.unwrap();
+                assert_eq!(metrics.active_requests(), 1);
+                drop(tx);
+            }
+        });
         let res = client
-            .get(format!("http://{origin_addr}/metrics"))
+            .post(format!("http://{origin_addr}/upload"))
+            .body(body)
             .send()
             .await
             .anyerr()?;
+        body_task.await.expect("task panicked");
         assert_eq!(res.status(), StatusCode::OK);
         let body = res.bytes().await.anyerr()?;
-        assert_eq!(body.as_ref(), b"metrics-origin GET /metrics");
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(body.as_ref(), b"origin POST /upload: hello");
+        assert_eq!(metrics.active_requests(), 0);
         assert_eq!(metrics.requests_accepted.get(), 1);
         assert_eq!(metrics.requests_accepted_h1.get(), 1);
         assert_eq!(metrics.requests_completed.get(), 1);
         assert_eq!(metrics.requests_denied.get(), 0);
-        assert_eq!(metrics.active_requests(), 0);
         assert!(metrics.bytes_to_upstream.get() > 0);
         assert!(metrics.bytes_from_upstream.get() > 0);
+        assert_eq!(metrics.iroh_connections_opened.get(), 1);
+        assert_eq!(metrics.iroh_connections_closed_error.get(), 0);
+        assert_eq!(metrics.iroh_connections_closed_idle.get(), 0);
+        assert_eq!(metrics.active_iroh_connections(), 1);
         drop(origin_task);
         drop(proxy_task);
         upstream_router.shutdown().await.anyerr()?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(metrics.iroh_connections_closed_error.get(), 1);
         Ok(())
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn http_metrics_deny_behavior() -> Result {
         let mode = ProxyMode::Http(HttpProxyOpts::new(RejectAll));
         let (proxy_addr, _, metrics, proxy_task) =

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,7 +30,7 @@ use crate::{
         RequestHandler, SrcAddr,
         opts::{RequestHandlerChain, StaticForwardProxy, StaticReverseProxy},
     },
-    upstream::{AcceptAll, AuthError, AuthHandler, UpstreamProxy},
+    upstream::{AcceptAll, AuthError, AuthHandler, UpstreamMetrics, UpstreamProxy},
     util::Prebuffered,
 };
 
@@ -49,27 +49,27 @@ async fn bind_endpoint() -> Result<Endpoint, BindError> {
 
 /// Spawns an upstream iroh proxy that accepts all requests.
 async fn spawn_upstream_proxy() -> Result<(Router, EndpointId)> {
+    let (router, id, _metrics) = spawn_upstream_proxy_with_auth(AcceptAll).await?;
+    Ok((router, id))
+}
+
+async fn spawn_upstream_proxy_with_metrics() -> Result<(Router, EndpointId, Arc<UpstreamMetrics>)> {
     spawn_upstream_proxy_with_auth(AcceptAll).await
 }
 
 /// Spawns an upstream iroh proxy with a custom auth handler.
 async fn spawn_upstream_proxy_with_auth(
     auth: impl AuthHandler + 'static,
-) -> Result<(Router, EndpointId)> {
+) -> Result<(Router, EndpointId, Arc<UpstreamMetrics>)> {
     let endpoint = bind_endpoint().await?;
     let upstream_proxy = UpstreamProxy::new(auth)?;
     let metrics = upstream_proxy.metrics();
-    let on_shutdown = upstream_proxy.on_shutdown();
-    tokio::spawn(async move {
-        on_shutdown.await;
-        debug!("metrics: {metrics:?}");
-    });
     let router = Router::builder(endpoint)
         .accept(ALPN, upstream_proxy)
         .spawn();
     let endpoint_id = router.endpoint().id();
     debug!(endpoint_id=%endpoint_id.fmt_short(), "spawned upstream proxy");
-    Ok((router, endpoint_id))
+    Ok((router, endpoint_id, metrics))
 }
 
 /// Spawns a downstream proxy with given mode and returns (addr, endpoint_id, task).
@@ -578,7 +578,7 @@ async fn test_upstream_auth_endpoint() -> Result {
     let (proxy_addr, downstream_id, proxy_task) = spawn_downstream_proxy(mode_placeholder).await?;
 
     // Upstream that only allows this specific downstream
-    let (upstream_router, upstream_id) =
+    let (upstream_router, upstream_id, _metrics) =
         spawn_upstream_proxy_with_auth(AllowEndpoints(vec![downstream_id])).await?;
 
     // Authorized request should succeed
@@ -630,7 +630,7 @@ async fn test_upstream_auth_authority() -> Result {
     let (denied_addr, _denied_task) = spawn_origin_server("denied").await?;
 
     // Upstream that only allows connections to allowed_addr
-    let (upstream_router, upstream_id) =
+    let (upstream_router, upstream_id, _metrics) =
         spawn_upstream_proxy_with_auth(AllowAuthorities(vec![allowed_addr.to_string()])).await?;
 
     // Downstream forward proxy using CONNECT
@@ -1867,9 +1867,10 @@ mod metrics {
     #[traced_test]
     async fn http_metrics_track_requests() -> Result {
         let (origin_addr, origin_task) = spawn_origin_server_echo_body("origin").await?;
-        let (upstream_router, upstream_id) = spawn_upstream_proxy().await?;
+        let (upstream_router, upstream_id, upstream_metrics) =
+            spawn_upstream_proxy_with_metrics().await?;
         let mode = ProxyMode::Http(HttpProxyOpts::new(StaticForwardProxy(upstream_id)));
-        let (proxy_addr, _, metrics, proxy_task) =
+        let (proxy_addr, _, downstream_metrics, proxy_task) =
             spawn_downstream_proxy_with_metrics(mode).await?;
         let client = reqwest::Client::builder()
             .proxy(reqwest::Proxy::http(format!("http://{proxy_addr}")).anyerr()?)
@@ -1881,11 +1882,11 @@ mod metrics {
         // we spawn a separate task to ensure active_requests is 1 if the body is not yet terminated.
         // need to do this in a task to not deadlock, because post.send().await waits for the response.
         let body_task = tokio::task::spawn({
-            let metrics = metrics.clone();
+            let downstream_metrics = downstream_metrics.clone();
             async move {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 tx.send(Ok(Bytes::from("hello"))).await.unwrap();
-                assert_eq!(metrics.active_requests(), 1);
+                assert_eq!(downstream_metrics.active_requests(), 1);
                 drop(tx);
             }
         });
@@ -1899,22 +1900,37 @@ mod metrics {
         assert_eq!(res.status(), StatusCode::OK);
         let body = res.bytes().await.anyerr()?;
         assert_eq!(body.as_ref(), b"origin POST /upload: hello");
-        assert_eq!(metrics.active_requests(), 0);
-        assert_eq!(metrics.requests_accepted.get(), 1);
-        assert_eq!(metrics.requests_accepted_h1.get(), 1);
-        assert_eq!(metrics.requests_completed.get(), 1);
-        assert_eq!(metrics.requests_denied.get(), 0);
-        assert!(metrics.bytes_to_upstream.get() > 0);
-        assert!(metrics.bytes_from_upstream.get() > 0);
-        assert_eq!(metrics.iroh_connections_opened.get(), 1);
-        assert_eq!(metrics.iroh_connections_closed_error.get(), 0);
-        assert_eq!(metrics.iroh_connections_closed_idle.get(), 0);
-        assert_eq!(metrics.active_iroh_connections(), 1);
+        assert_eq!(downstream_metrics.active_requests(), 0);
+        assert_eq!(downstream_metrics.requests_accepted.get(), 1);
+        assert_eq!(downstream_metrics.requests_accepted_h1.get(), 1);
+        assert_eq!(downstream_metrics.requests_completed.get(), 1);
+        assert_eq!(downstream_metrics.requests_denied.get(), 0);
+        assert!(downstream_metrics.bytes_to_upstream.get() > 0);
+        assert!(downstream_metrics.bytes_from_upstream.get() > 0);
+        assert_eq!(downstream_metrics.iroh_connections_opened.get(), 1);
+        assert_eq!(downstream_metrics.iroh_connections_closed_error.get(), 0);
+        assert_eq!(downstream_metrics.iroh_connections_closed_idle.get(), 0);
+        assert_eq!(downstream_metrics.active_iroh_connections(), 1);
         drop(origin_task);
         drop(proxy_task);
         upstream_router.shutdown().await.anyerr()?;
         tokio::time::sleep(Duration::from_millis(50)).await;
-        assert_eq!(metrics.iroh_connections_closed_error.get(), 1);
+        assert_eq!(downstream_metrics.iroh_connections_closed_error.get(), 1);
+
+        let origin_metrics = upstream_metrics
+            .get(&Authority::from_authority_str(&origin_addr.to_string()).unwrap())
+            .expect("exists");
+
+        assert_eq!(
+            origin_metrics.bytes_from_origin(),
+            downstream_metrics.bytes_from_upstream.get()
+        );
+        assert_eq!(
+            origin_metrics.bytes_to_origin(),
+            downstream_metrics.bytes_to_upstream.get()
+        );
+
+        debug!("downstream metrics: {downstream_metrics:#?}");
         Ok(())
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,10 @@
-use std::{collections::HashMap, net::SocketAddr, str::FromStr, sync::OnceLock, time::Duration};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    str::FromStr,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use http::StatusCode;
 use hyper_util::rt::TokioExecutor;
@@ -20,8 +26,8 @@ use crate::{
     ALPN, Authority, HttpProxyRequest, HttpProxyRequestKind, HttpRequest, HttpResponse,
     IROH_DESTINATION_HEADER,
     downstream::{
-        Deny, DownstreamProxy, EndpointAuthority, HttpProxyOpts, ProxyMode, RequestHandler,
-        SrcAddr,
+        Deny, DownstreamMetrics, DownstreamProxy, EndpointAuthority, HttpProxyOpts, ProxyMode,
+        RequestHandler, SrcAddr,
         opts::{RequestHandlerChain, StaticForwardProxy, StaticReverseProxy},
     },
     upstream::{AcceptAll, AuthError, AuthHandler, UpstreamProxy},
@@ -78,6 +84,25 @@ async fn spawn_downstream_proxy(
     debug!(endpoint_id=%endpoint_id.fmt_short(), %tcp_addr, "spawned downstream proxy");
     let task = tokio::spawn(async move { proxy.forward_tcp_listener(listener, mode).await });
     Ok((tcp_addr, endpoint_id, AbortOnDropHandle::new(task)))
+}
+
+async fn spawn_downstream_proxy_with_metrics(
+    mode: ProxyMode,
+) -> Result<(
+    SocketAddr,
+    EndpointId,
+    Arc<DownstreamMetrics>,
+    AbortOnDropHandle<Result>,
+)> {
+    let endpoint = bind_endpoint().await?;
+    let endpoint_id = endpoint.id();
+    let proxy = DownstreamProxy::new(endpoint, Default::default());
+    let metrics = proxy.metrics().clone();
+    let listener = TcpListener::bind("localhost:0").await?;
+    let tcp_addr = listener.local_addr()?;
+    debug!(endpoint_id=%endpoint_id.fmt_short(), %tcp_addr, "spawned downstream proxy");
+    let task = tokio::spawn(async move { proxy.forward_tcp_listener(listener, mode).await });
+    Ok((tcp_addr, endpoint_id, metrics, AbortOnDropHandle::new(task)))
 }
 
 /// Spawns a simple HTTP origin server that echoes back "{label} {method} {path}".
@@ -1813,6 +1838,80 @@ mod origin_server {
             }
         }
 
+        Ok(())
+    }
+}
+
+mod metrics {
+    use super::*;
+
+    struct RejectAll;
+
+    impl RequestHandler for RejectAll {
+        async fn handle_request(
+            &self,
+            _src_addr: SrcAddr,
+            _req: &mut HttpRequest,
+        ) -> Result<EndpointId, Deny> {
+            Err(Deny::bad_request("denied by RejectAll"))
+        }
+    }
+
+    #[tokio::test]
+    async fn http_metrics_track_requests() -> Result {
+        let (origin_addr, origin_task) = spawn_origin_server("metrics-origin").await?;
+        let (upstream_router, upstream_id) = spawn_upstream_proxy().await?;
+        let mode = ProxyMode::Http(HttpProxyOpts::new(StaticForwardProxy(upstream_id)));
+        let (proxy_addr, _, metrics, proxy_task) =
+            spawn_downstream_proxy_with_metrics(mode).await?;
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::http(format!("http://{proxy_addr}")).anyerr()?)
+            .build()
+            .anyerr()?;
+        let res = client
+            .get(format!("http://{origin_addr}/metrics"))
+            .send()
+            .await
+            .anyerr()?;
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = res.bytes().await.anyerr()?;
+        assert_eq!(body.as_ref(), b"metrics-origin GET /metrics");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(metrics.requests_accepted.get(), 1);
+        assert_eq!(metrics.requests_accepted_h1.get(), 1);
+        assert_eq!(metrics.requests_completed.get(), 1);
+        assert_eq!(metrics.requests_denied.get(), 0);
+        assert_eq!(metrics.active_requests(), 0);
+        assert!(metrics.bytes_to_upstream.get() > 0);
+        assert!(metrics.bytes_from_upstream.get() > 0);
+        drop(origin_task);
+        drop(proxy_task);
+        upstream_router.shutdown().await.anyerr()?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn http_metrics_deny_behavior() -> Result {
+        let mode = ProxyMode::Http(HttpProxyOpts::new(RejectAll));
+        let (proxy_addr, _, metrics, proxy_task) =
+            spawn_downstream_proxy_with_metrics(mode).await?;
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::http(format!("http://{proxy_addr}")).anyerr()?)
+            .build()
+            .anyerr()?;
+        let res = client
+            .get("http://example.com/denied")
+            .send()
+            .await
+            .anyerr()?;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(metrics.requests_denied.get(), 1);
+        assert_eq!(metrics.requests_completed.get(), 0);
+        assert_eq!(metrics.requests_failed.get(), 0);
+        assert_eq!(metrics.active_requests(), 0);
+
+        drop(proxy_task);
         Ok(())
     }
 }

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -78,7 +78,7 @@ pub struct UpstreamProxy {
     shutdown: CancellationToken,
     tasks: TaskTracker,
     http_client: reqwest::Client,
-    metrics: Arc<Metrics>,
+    metrics: Arc<UpstreamMetrics>,
 }
 
 impl ProtocolHandler for UpstreamProxy {
@@ -125,7 +125,7 @@ impl UpstreamProxy {
     }
 
     /// Returns the metrics tracker for this upstream proxy.
-    pub fn metrics(&self) -> Arc<Metrics> {
+    pub fn metrics(&self) -> Arc<UpstreamMetrics> {
         self.metrics.clone()
     }
 
@@ -190,7 +190,7 @@ impl UpstreamProxy {
         mut downstream_send: SendStream,
         downstream_recv: RecvStream,
         http_client: reqwest::Client,
-        metrics: Arc<Metrics>,
+        metrics: Arc<UpstreamMetrics>,
     ) -> Result<()> {
         let mut downstream_recv = Prebuffered::new(downstream_recv, HEADER_SECTION_MAX_LENGTH);
         let (request_len, req) = HttpRequest::peek(&mut downstream_recv).await?;
@@ -441,9 +441,11 @@ async fn forward_reqwest_response(
     req_metrics: Arc<TargetMetrics>,
 ) -> Result<usize> {
     let mut send = TrackedWrite::new(send, |d| {
+        println!("TRACK HEADER {d}");
         req_metrics.bytes_from_origin.inc_by(d);
     });
     write_response(&response, &mut send).await?;
+    println!("HEADER TOTAL {}", req_metrics.bytes_from_origin.get());
     let send = send.into_inner();
     let mut total = 0;
     let mut body = response.bytes_stream();
@@ -451,6 +453,7 @@ async fn forward_reqwest_response(
         let bytes = bytes.anyerr()?;
         total += bytes.len();
         req_metrics.bytes_from_origin.inc_by(bytes.len() as u64);
+        println!("TRACK BODY {}", bytes.len());
         send.write_chunk(bytes).await.anyerr()?;
     }
     send.finish().anyerr()?;

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -27,7 +27,10 @@ use crate::{
         HttpProxyRequestKind, HttpRequest, absolute_target_to_origin_form,
         filter_hop_by_hop_headers,
     },
-    util::{Prebuffered, TrackedRead, TrackedWrite, forward_bidi, recv_to_stream},
+    util::{
+        Prebuffered, StreamEvent, TrackedRead, TrackedStream, TrackedWrite, forward_bidi, nores,
+        recv_to_stream,
+    },
 };
 
 mod auth;
@@ -318,12 +321,15 @@ impl UpstreamProxy {
                     }
                 } else {
                     debug!(%target, "origin request: connecting to origin");
-                    let body = recv_stream_to_body(downstream_recv, {
+                    let body = {
                         let req_metrics = req_metrics.clone();
-                        move |d| {
-                            req_metrics.bytes_to_origin.inc_by(d);
-                        }
-                    });
+                        let body = recv_to_stream(downstream_recv);
+                        let body = TrackedStream::new(body, move |ev| match ev {
+                            StreamEvent::Data(n) => nores(req_metrics.bytes_to_origin.inc_by(n)),
+                            _ => {}
+                        });
+                        reqwest::Body::wrap_stream(body)
+                    };
 
                     // Filter hop-by-hop headers before forwarding to upstream per RFC 9110.
                     let mut headers = req.headers;
@@ -460,14 +466,6 @@ async fn error_response_and_finish(mut send: SendStream) -> Result<(), n0_error:
         .ok();
     send.finish().anyerr()?;
     Ok(())
-}
-
-// Converts a [`Prebuffered`] recv stream into a streaming [`reqwest::Body`].
-fn recv_stream_to_body(
-    recv: Prebuffered<RecvStream>,
-    track_data: impl Fn(u64) + Send + 'static,
-) -> reqwest::Body {
-    reqwest::Body::wrap_stream(recv_to_stream(recv, track_data))
 }
 
 async fn write_response(

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -1,10 +1,8 @@
 use std::{
-    pin::Pin,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    task::Poll,
     time::Duration,
 };
 
@@ -17,7 +15,7 @@ use iroh::{
 use n0_error::{Result, StackResultExt, StdResultExt};
 use n0_future::stream::StreamExt;
 use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt},
+    io::{AsyncWrite, AsyncWriteExt},
     net::TcpStream,
 };
 use tokio_util::{future::FutureExt, sync::CancellationToken, task::TaskTracker};
@@ -29,7 +27,7 @@ use crate::{
         HttpProxyRequestKind, HttpRequest, absolute_target_to_origin_form,
         filter_hop_by_hop_headers,
     },
-    util::{Prebuffered, forward_bidi, recv_to_stream},
+    util::{Prebuffered, TrackedRead, TrackedWrite, forward_bidi, recv_to_stream},
 };
 
 mod auth;
@@ -493,79 +491,4 @@ async fn write_response(
     }
     send.write_all(b"\r\n").await.anyerr()?;
     Ok(())
-}
-
-struct TrackedRead<R, F> {
-    inner: R,
-    inc: F,
-}
-
-impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> TrackedRead<R, F> {
-    fn new(inner: R, inc: F) -> Self {
-        Self { inner, inc }
-    }
-}
-
-impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> AsyncRead for TrackedRead<R, F> {
-    fn poll_read(
-        self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let before = buf.filled().len();
-        let this = self.get_mut();
-        let result = std::task::ready!(Pin::new(&mut this.inner).poll_read(cx, buf));
-        let after = buf.filled().len();
-        let diff = after - before;
-        if diff > 0 {
-            (this.inc)(diff as u64)
-        }
-        Poll::Ready(result)
-    }
-}
-
-struct TrackedWrite<W, F> {
-    inner: W,
-    inc: F,
-}
-
-impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> TrackedWrite<W, F> {
-    fn new(inner: W, inc: F) -> Self {
-        Self { inner, inc }
-    }
-
-    fn into_inner(self) -> W {
-        self.inner
-    }
-}
-
-impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> AsyncWrite for TrackedWrite<W, F> {
-    fn poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let this = self.get_mut();
-        let result = std::task::ready!(Pin::new(&mut this.inner).poll_write(cx, buf));
-        if let Ok(n) = &result {
-            if *n > 0 {
-                (this.inc)(*n as u64);
-            }
-        }
-        Poll::Ready(result)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
-    }
-
-    fn poll_shutdown(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
-    }
 }

--- a/src/upstream/metrics.rs
+++ b/src/upstream/metrics.rs
@@ -12,7 +12,7 @@ use crate::Authority;
 /// Tracks connection and request counts across all targets, and provides
 /// access to per-target metrics via [`Metrics::get`] and [`Metrics::for_each`].
 #[derive(Debug, Default)]
-pub struct Metrics {
+pub struct UpstreamMetrics {
     targets: RwLock<BTreeMap<Authority, Arc<TargetMetrics>>>,
     pub(super) connections_accepted: Counter,
     pub(super) connections_completed: Counter,
@@ -22,7 +22,7 @@ pub struct Metrics {
     pub(super) requests_failed: Counter,
 }
 
-impl Metrics {
+impl UpstreamMetrics {
     /// Returns the total number of denied requests across all targets.
     pub fn denied_requests(&self) -> u64 {
         self.requests_denied.get()

--- a/src/util.rs
+++ b/src/util.rs
@@ -69,15 +69,13 @@ pub(crate) fn recv_to_stream(
 
 #[pin_project(PinnedDrop)]
 #[derive(Debug)]
-pub struct TrackedStream<S, F, G = ()>
+pub struct TrackedStream<S, F>
 where
     F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
-    G: Unpin + Send + 'static,
 {
     #[pin]
     inner: S,
     on_event: Option<F>,
-    _guard: Option<G>,
 }
 
 #[derive(Debug)]
@@ -95,30 +93,14 @@ where
         Self {
             inner,
             on_event: Some(on_event),
-            _guard: None,
-        }
-    }
-}
-
-impl<S, F, G> TrackedStream<S, F, G>
-where
-    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
-    G: Unpin + Send + 'static,
-{
-    pub fn with_guard(inner: S, guard: Option<G>, on_event: F) -> Self {
-        Self {
-            inner,
-            on_event: Some(on_event),
-            _guard: guard,
         }
     }
 }
 
 #[pinned_drop]
-impl<S, F, G> PinnedDrop for TrackedStream<S, F, G>
+impl<S, F> PinnedDrop for TrackedStream<S, F>
 where
     F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
-    G: Unpin + Send + 'static,
 {
     fn drop(self: Pin<&mut Self>) {
         if let Some(f) = self.project().on_event.take() {
@@ -127,11 +109,10 @@ where
     }
 }
 
-impl<S, F, G> Stream for TrackedStream<S, F, G>
+impl<S, F> Stream for TrackedStream<S, F>
 where
     S: Stream<Item = Result<Bytes, io::Error>> + Send,
     F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
-    G: Unpin + Send + 'static,
 {
     type Item = S::Item;
 
@@ -179,9 +160,9 @@ impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> TrackedRead<R, F> {
 }
 
 impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin, G: Unpin> TrackedRead<R, F, G> {
-    pub(crate) fn into_parts(self) -> (R, F) {
-        (self.inner, self.inc)
-    }
+    // pub(crate) fn into_parts(self) -> (R, F) {
+    //     (self.inner, self.inc)
+    // }
 
     pub(crate) fn with_guard<GG>(self, guard: GG) -> TrackedRead<R, F, GG> {
         TrackedRead {
@@ -210,6 +191,7 @@ impl<R: AsyncRead + Unpin + Send, F: Fn(u64) + Unpin + Send, G: Unpin + Send> Pr
     async fn buffer_more(&mut self) -> tokio::io::Result<usize> {
         match self.inner.buffer_more().await {
             Ok(n) => {
+                println!("INC from bm {n}");
                 (self.inc)(n as u64);
                 Ok(n)
             }
@@ -231,6 +213,7 @@ impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin, G: Unpin> AsyncRead for TrackedRe
             let after = buf.filled().len();
             let diff = after.saturating_sub(before);
             if diff > 0 {
+                println!("INC from ar {diff}");
                 (this.inc)(diff as u64);
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,17 +1,18 @@
 use std::{
     io,
     pin::Pin,
-    task::{Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use bytes::Bytes;
 use iroh::endpoint::RecvStream;
 use n0_error::{Result, StackResultExt};
 use n0_future::{Stream, stream};
+use pin_project::{pin_project, pinned_drop};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tracing::trace;
 
-pub(crate) use self::prebuffered::Prebuffered;
+pub(crate) use self::prebuffered::{Prebufferable, Prebuffered};
 
 mod prebuffered;
 
@@ -48,48 +49,181 @@ pub(crate) async fn forward_bidi(
 // Converts a [`Prebuffered`] recv stream into a stream of [`Bytes`].
 pub(crate) fn recv_to_stream(
     recv: Prebuffered<RecvStream>,
-    inc: impl Fn(u64),
-) -> impl Stream<Item = io::Result<Bytes>> {
+) -> impl Stream<Item = io::Result<Bytes>> + Send + 'static {
     let (init, recv) = recv.into_parts();
-    stream::unfold(
-        (inc, Some(init), recv),
-        async |(inc, mut init, mut recv)| {
-            let item: io::Result<Bytes> = if let Some(init) = init.take() {
-                (inc)(init.len() as u64);
-                Ok(init)
-            } else {
-                match recv.read_chunk(8192, true).await {
-                    Err(err) => Err(err.into()),
-                    Ok(None) => return None,
-                    Ok(Some(chunk)) => {
-                        (inc)(chunk.bytes.len() as u64);
-                        Ok(chunk.bytes)
-                    }
+    stream::unfold((Some(init), recv), async |(mut init, mut recv)| {
+        let item: io::Result<Bytes> = if let Some(init) = init.take() {
+            Ok(init)
+        } else {
+            match recv.read_chunk(8192, true).await {
+                Err(err) => Err(err.into()),
+                Ok(None) => {
+                    return None;
                 }
-            };
-            Some((item, (inc, None, recv)))
-        },
-    )
+                Ok(Some(chunk)) => Ok(chunk.bytes),
+            }
+        };
+        Some((item, (None, recv)))
+    })
+}
+
+#[pin_project(PinnedDrop)]
+#[derive(Debug)]
+pub struct TrackedStream<S, F, G = ()>
+where
+    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
+    G: Unpin + Send + 'static,
+{
+    #[pin]
+    inner: S,
+    on_event: Option<F>,
+    _guard: Option<G>,
+}
+
+#[derive(Debug)]
+pub enum StreamEvent<'a> {
+    Data(u64),
+    Done(Result<(), &'a io::Error>),
+}
+
+impl<S, F> TrackedStream<S, F>
+where
+    S: Stream<Item = Result<Bytes, io::Error>> + Send,
+    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
+{
+    pub fn new(inner: S, on_event: F) -> Self {
+        Self {
+            inner,
+            on_event: Some(on_event),
+            _guard: None,
+        }
+    }
+}
+
+impl<S, F, G> TrackedStream<S, F, G>
+where
+    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
+    G: Unpin + Send + 'static,
+{
+    pub fn with_guard(inner: S, guard: Option<G>, on_event: F) -> Self {
+        Self {
+            inner,
+            on_event: Some(on_event),
+            _guard: guard,
+        }
+    }
+}
+
+#[pinned_drop]
+impl<S, F, G> PinnedDrop for TrackedStream<S, F, G>
+where
+    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
+    G: Unpin + Send + 'static,
+{
+    fn drop(self: Pin<&mut Self>) {
+        if let Some(f) = self.project().on_event.take() {
+            f(StreamEvent::Done(Ok(())));
+        }
+    }
+}
+
+impl<S, F, G> Stream for TrackedStream<S, F, G>
+where
+    S: Stream<Item = Result<Bytes, io::Error>> + Send,
+    F: for<'a> Fn(StreamEvent<'a>) + Unpin + Send + 'static,
+    G: Unpin + Send + 'static,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        match ready!(this.inner.poll_next(cx)) {
+            None => {
+                if let Some(f) = this.on_event.take() {
+                    f(StreamEvent::Done(Ok(())));
+                }
+                Poll::Ready(None)
+            }
+            Some(Ok(bytes)) => {
+                if let Some(f) = this.on_event.as_ref() {
+                    f(StreamEvent::Data(bytes.len() as u64));
+                }
+                Poll::Ready(Some(Ok(bytes)))
+            }
+            Some(Err(e)) => {
+                if let Some(f) = this.on_event.take() {
+                    f(StreamEvent::Done(Err(&e)));
+                }
+                Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
 }
 
 /// Tracks bytes read and reports them via `inc`.
-pub(crate) struct TrackedRead<R, F> {
+pub(crate) struct TrackedRead<R, F, G = ()> {
     inner: R,
     inc: F,
+    _guard: Option<G>,
 }
 
 impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> TrackedRead<R, F> {
     pub(crate) fn new(inner: R, inc: F) -> Self {
-        Self { inner, inc }
+        Self {
+            inner,
+            inc,
+            _guard: None,
+        }
     }
 }
 
-impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> AsyncRead for TrackedRead<R, F> {
+impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin, G: Unpin> TrackedRead<R, F, G> {
+    pub(crate) fn into_parts(self) -> (R, F) {
+        (self.inner, self.inc)
+    }
+
+    pub(crate) fn with_guard<GG>(self, guard: GG) -> TrackedRead<R, F, GG> {
+        TrackedRead {
+            inner: self.inner,
+            inc: self.inc,
+            _guard: Some(guard),
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin + Send, F: Fn(u64) + Unpin + Send, G: Unpin + Send> Prebufferable
+    for TrackedRead<Prebuffered<R>, F, G>
+{
+    fn is_full(&self) -> bool {
+        self.inner.is_full()
+    }
+
+    fn buffer(&self) -> &[u8] {
+        self.inner.buffer()
+    }
+
+    fn discard(&mut self, n: usize) {
+        self.inner.discard(n)
+    }
+
+    async fn buffer_more(&mut self) -> tokio::io::Result<usize> {
+        match self.inner.buffer_more().await {
+            Ok(n) => {
+                (self.inc)(n as u64);
+                Ok(n)
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin, G: Unpin> AsyncRead for TrackedRead<R, F, G> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
+    ) -> Poll<io::Result<()>> {
         let before = buf.filled().len();
         let this = self.get_mut();
         let result = Pin::new(&mut this.inner).poll_read(cx, buf);
@@ -105,27 +239,41 @@ impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> AsyncRead for TrackedRead<R, F> {
 }
 
 /// Tracks bytes written and reports them via `inc`.
-pub(crate) struct TrackedWrite<W, F> {
+pub(crate) struct TrackedWrite<W, F, G = ()> {
     inner: W,
     inc: F,
+    _guard: Option<G>,
 }
 
 impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> TrackedWrite<W, F> {
     pub(crate) fn new(inner: W, inc: F) -> Self {
-        Self { inner, inc }
+        Self {
+            inner,
+            inc,
+            _guard: None,
+        }
     }
-
+}
+impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin, G: Unpin> TrackedWrite<W, F, G> {
     pub(crate) fn into_inner(self) -> W {
         self.inner
     }
+
+    pub(crate) fn with_guard<GG>(self, guard: GG) -> TrackedWrite<W, F, GG> {
+        TrackedWrite {
+            inner: self.inner,
+            inc: self.inc,
+            _guard: Some(guard),
+        }
+    }
 }
 
-impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> AsyncWrite for TrackedWrite<W, F> {
+impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin, G: Unpin> AsyncWrite for TrackedWrite<W, F, G> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
+    ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
         let result = Pin::new(&mut this.inner).poll_write(cx, buf);
         if let Poll::Ready(Ok(n)) = result {
@@ -136,11 +284,11 @@ impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> AsyncWrite for TrackedWrite<W, F
         result
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.get_mut().inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
     }
 }
@@ -154,3 +302,5 @@ macro_rules! inc_by_delta {
         }
     }};
 }
+
+pub(crate) fn nores<T>(_r: T) {}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,8 @@
-use std::io;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use iroh::endpoint::RecvStream;
@@ -66,4 +70,87 @@ pub(crate) fn recv_to_stream(
             Some((item, (inc, None, recv)))
         },
     )
+}
+
+/// Tracks bytes read and reports them via `inc`.
+pub(crate) struct TrackedRead<R, F> {
+    inner: R,
+    inc: F,
+}
+
+impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> TrackedRead<R, F> {
+    pub(crate) fn new(inner: R, inc: F) -> Self {
+        Self { inner, inc }
+    }
+}
+
+impl<R: AsyncRead + Unpin, F: Fn(u64) + Unpin> AsyncRead for TrackedRead<R, F> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let before = buf.filled().len();
+        let this = self.get_mut();
+        let result = Pin::new(&mut this.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = &result {
+            let after = buf.filled().len();
+            let diff = after.saturating_sub(before);
+            if diff > 0 {
+                (this.inc)(diff as u64);
+            }
+        }
+        result
+    }
+}
+
+/// Tracks bytes written and reports them via `inc`.
+pub(crate) struct TrackedWrite<W, F> {
+    inner: W,
+    inc: F,
+}
+
+impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> TrackedWrite<W, F> {
+    pub(crate) fn new(inner: W, inc: F) -> Self {
+        Self { inner, inc }
+    }
+
+    pub(crate) fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin> AsyncWrite for TrackedWrite<W, F> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.get_mut();
+        let result = Pin::new(&mut this.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = result {
+            if n > 0 {
+                (this.inc)(n as u64);
+            }
+        }
+        result
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+}
+
+#[macro_export]
+macro_rules! inc_by_delta {
+    ($metrics:ident, $field:tt) => {{
+        let metrics = $metrics.clone();
+        move |d| {
+            metrics.$field.inc_by(d);
+        }
+    }};
 }

--- a/src/util/prebuffered.rs
+++ b/src/util/prebuffered.rs
@@ -25,6 +25,36 @@ pub struct Prebuffered<R> {
     max_len: usize,
 }
 
+pub trait Prebufferable: Send + Unpin {
+    fn is_full(&self) -> bool;
+    /// Returns the unconsumed buffered bytes.
+    fn buffer(&self) -> &[u8];
+
+    /// Discards `n` bytes from the front of the buffer.
+    fn discard(&mut self, n: usize);
+
+    /// Buffers more data from the inner reader.
+    fn buffer_more(&mut self) -> impl Future<Output = io::Result<usize>> + Send;
+}
+
+impl<R: AsyncRead + Unpin + Send> Prebufferable for Prebuffered<R> {
+    fn is_full(&self) -> bool {
+        Prebuffered::is_full(self)
+    }
+
+    fn buffer(&self) -> &[u8] {
+        Prebuffered::buffer(self)
+    }
+
+    fn discard(&mut self, n: usize) {
+        Prebuffered::discard(self, n)
+    }
+
+    fn buffer_more(&mut self) -> impl Future<Output = io::Result<usize>> + Send {
+        Prebuffered::buffer_more(self)
+    }
+}
+
 impl<R: AsyncRead + Unpin> Prebuffered<R> {
     /// Creates a new `Prebuffered` wrapper.
     pub(crate) fn new(inner: R, max_len: usize) -> Self {


### PR DESCRIPTION
**Edit: Closed in favor of #16**

This adds `DownstreamProxy::metrics()` which returns `DownstreamMetrics`.

The PR also fixes a bug, which became apparent while checking the metrics. W need to maintain a guard so that the connection guard returned from the connection pool is never dropped before the request was processed fully. Previously, it could happen that a connection would be marked idle, even though it was still in use.

See the diff for which metrics are currently supported. Not all metrics are fully tested yet, I will add more tests.

To export  the metrics into the openmetrics format, you can use `iroh_metrics::Registry`:

```rust
let proxy = DownstreamProxy::new();
let mut registry = iroh_metrics::Registry::default();
registry.register(proxy.metrics().clone());

// registry can now be sent to other tasks

// encode manually into a openmetrics string
let mut buf = String::new();
registry.encode_openmetrics_to_writer(&mut buf);

// start an openmetrics http server (to be scraped by prometheus)
iroh_metrics::service::start_http_server(Arc::new(registry));
```