### PR TITLE
chore: cleanup before 0.1.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 name = "iroh-proxy-utils"
 version = "0.1.0"
 edition = "2024"
+description = "HTTP and TCP proxy utilities for iroh peer-to-peer connections"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/n0-computer/iroh-proxy-utils"
+authors = ["n0 team"]
+documentation = "https://docs.rs/iroh-proxy-utils"
+keywords = ["iroh", "proxy", "http", "quic", "p2p"]
+categories = ["network-programming"]
+rust-version = "1.85"
 
 [dependencies]
 bytes = "1.11.0"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![CI](https://github.com/n0-computer/iroh-proxy-utils/actions/workflows/ci.yml/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/iroh-proxy-utils.svg)](https://crates.io/crates/iroh-proxy-utils)
-[![Documentation](https://docs.rs/iroh-proxy-utils/badge.svg)](https://docs.rs/redb)
-[![License](https://img.shields.io/crates/l/iroh-proxy-utils)](https://crates.io/crates/redb)
+[![docs.rs](https://img.shields.io/docsrs/iroh-proxy-utils)](https://docs.rs/iroh-proxy-utils)
+[![License](https://img.shields.io/crates/l/iroh-proxy-utils)](https://crates.io/crates/iroh-proxy-utils)
 
 Primitives for TCP and HTTP proxying over [iroh](https://github.com/n0-computer/iroh) connections.
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -126,7 +126,7 @@ impl Authority {
             None => match uri.scheme() {
                 Some(scheme) if *scheme == Scheme::HTTP => 80,
                 Some(scheme) if *scheme == Scheme::HTTPS => 443,
-                _ => Err(anyerr!("Expected URI to with port or http(s) scheme"))?,
+                _ => Err(anyerr!("Expected URI with port or http(s) scheme"))?,
             },
         };
         Ok(Self {
@@ -494,7 +494,7 @@ pub enum HttpProxyRequestKind {
 }
 
 impl HttpProxyRequestKind {
-    /// Returns a [`ProxyTargetId`] for this request.
+    /// Returns the [`Authority`] for this request.
     ///
     /// Returns an error if the absolute-form URI does not contain a port and does not have an HTTP(s) scheme.
     pub fn authority(&self) -> Result<Authority> {

--- a/src/upstream/metrics.rs
+++ b/src/upstream/metrics.rs
@@ -10,7 +10,7 @@ use crate::Authority;
 /// Aggregate metrics for an [`super::UpstreamProxy`] instance.
 ///
 /// Tracks connection and request counts across all targets, and provides
-/// access to per-target metrics via [`Metrics::get`] and [`Metrics::for_each`].
+/// access to per-target metrics via [`UpstreamMetrics::get`] and [`UpstreamMetrics::for_each`].
 #[derive(Debug, Default)]
 pub struct UpstreamMetrics {
     targets: RwLock<BTreeMap<Authority, Arc<TargetMetrics>>>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -274,6 +274,8 @@ impl<W: AsyncWrite + Unpin, F: Fn(u64) + Unpin, G: Unpin> AsyncWrite for Tracked
     }
 }
 
+/// Not part of the public API.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! inc_by_delta {
     ($metrics:ident, $field:tt) => {{


### PR DESCRIPTION
This commit prepares the crate for its initial 0.1.0 release on crates.io. It adds required package metadata to Cargo.toml, fixes broken doc links and badge URLs in the README, and corrects a small typo in an error message.