### PR TITLE
Track downstream client disconnect metrics

### DIFF
--- a/src/downstream.rs
+++ b/src/downstream.rs
@@ -1,4 +1,13 @@
-use std::{convert::Infallible, fmt::Debug, io, net::SocketAddr, sync::Arc};
+use std::{
+    convert::Infallible,
+    fmt::Debug,
+    io,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
 
 use bytes::Bytes;
 use http::{Method, StatusCode, Version, header};
@@ -35,7 +44,7 @@ use crate::{
     parse::{HttpRequest, HttpResponse},
     util::{
         Prebufferable, Prebuffered, StreamEvent, TrackedRead, TrackedStream, TrackedWrite,
-        forward_bidi, nores,
+        forward_bidi,
     },
 };
 
@@ -352,13 +361,32 @@ impl DownstreamProxy {
         // `conn` is a `ConnectionRef` guard handed out from the connection pool. Once it is dropped,
         // the connection is marked as idle, and will be closed after the idle timeout.
         let conn_guard = Arc::new(conn);
+        let request_bytes = Arc::new(RequestByteCounts::default());
 
         // We want to track bytes written to/from upstream. And we store the `conn_guard` into the streams.
         // Once both streams are dropped, the request is fully done, and we can drop the conn ref safely.
-        let mut upstream_send = TrackedWrite::new(send, inc_by_delta!(metrics, bytes_to_upstream))
-            .with_guard(conn_guard.clone());
-        let upstream_recv = TrackedRead::new(recv, inc_by_delta!(metrics, bytes_from_upstream))
-            .with_guard(conn_guard.clone());
+        let mut upstream_send = {
+            let metrics = metrics.clone();
+            let request_bytes = request_bytes.clone();
+            TrackedWrite::new(send, move |d| {
+                metrics.bytes_to_upstream.inc_by(d);
+                request_bytes
+                    .bytes_to_upstream
+                    .fetch_add(d, Ordering::Relaxed);
+            })
+            .with_guard(conn_guard.clone())
+        };
+        let upstream_recv = {
+            let metrics = metrics.clone();
+            let request_bytes = request_bytes.clone();
+            TrackedRead::new(recv, move |d| {
+                metrics.bytes_from_upstream.inc_by(d);
+                request_bytes
+                    .bytes_from_upstream
+                    .fetch_add(d, Ordering::Relaxed);
+            })
+            .with_guard(conn_guard.clone())
+        };
         // We need to prebuffer for reading the response before passing it on.
         let mut upstream_recv = Prebuffered::new(upstream_recv, HEADER_SECTION_MAX_LENGTH);
 
@@ -392,12 +420,12 @@ impl DownstreamProxy {
                     upstream_recv,
                     upstream_send,
                 ));
-                response_to_hyper::<tokio::io::Empty>(response, None, metrics)?
+                response_to_hyper::<tokio::io::Empty>(response, None, metrics, request_bytes)?
             } else if request.method == Method::CONNECT {
-                response_to_hyper::<tokio::io::Empty>(response, None, metrics)?
+                response_to_hyper::<tokio::io::Empty>(response, None, metrics, request_bytes)?
             } else {
                 spawn(forward_hyper_body_and_finish(body, upstream_send));
-                response_to_hyper(response, Some(upstream_recv), metrics)?
+                response_to_hyper(response, Some(upstream_recv), metrics, request_bytes)?
             }
         } else {
             // For non-upgrade requests: Forward the body and read the response concurrently.
@@ -413,7 +441,7 @@ impl DownstreamProxy {
                 status = %response.status,
                 "received response header from upstream"
             );
-            response_to_hyper(response, Some(upstream_recv), metrics)?
+            response_to_hyper(response, Some(upstream_recv), metrics, request_bytes)?
         };
 
         Ok(response)
@@ -578,10 +606,87 @@ impl ProxyError {
 
 type HyperBody = BoxBody<Bytes, io::Error>;
 
+#[derive(Debug, Default)]
+struct RequestByteCounts {
+    bytes_to_upstream: AtomicU64,
+    bytes_from_upstream: AtomicU64,
+}
+
+impl RequestByteCounts {
+    fn snapshot(&self) -> (u64, u64) {
+        (
+            self.bytes_to_upstream.load(Ordering::Relaxed),
+            self.bytes_from_upstream.load(Ordering::Relaxed),
+        )
+    }
+}
+
+#[derive(Debug)]
+struct ResponseBodyMetrics {
+    metrics: Arc<DownstreamMetrics>,
+    request_bytes: Arc<RequestByteCounts>,
+    content_length: Option<u64>,
+    body_bytes: AtomicU64,
+    finished: AtomicBool,
+}
+
+impl ResponseBodyMetrics {
+    fn new(
+        metrics: Arc<DownstreamMetrics>,
+        request_bytes: Arc<RequestByteCounts>,
+        content_length: Option<u64>,
+    ) -> Self {
+        Self {
+            metrics,
+            request_bytes,
+            content_length,
+            body_bytes: AtomicU64::new(0),
+            finished: AtomicBool::new(false),
+        }
+    }
+
+    fn record_body_bytes(&self, bytes: u64) {
+        let Some(content_length) = self.content_length else {
+            return;
+        };
+        let body_bytes = self.body_bytes.fetch_add(bytes, Ordering::Relaxed) + bytes;
+        if body_bytes >= content_length {
+            self.mark_completed();
+        }
+    }
+
+    fn mark_completed(&self) {
+        if !self.finished.swap(true, Ordering::Relaxed) {
+            self.metrics.requests_completed.inc();
+        }
+    }
+
+    fn mark_failed(&self) {
+        if !self.finished.swap(true, Ordering::Relaxed) {
+            self.metrics.requests_failed.inc();
+        }
+    }
+
+    fn mark_client_disconnect(&self) {
+        if self.finished.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        let (bytes_to_upstream, bytes_from_upstream) = self.request_bytes.snapshot();
+        self.metrics.client_disconnect_count.inc();
+        self.metrics
+            .client_disconnect_upstream_bytes
+            .inc_by(bytes_to_upstream);
+        self.metrics
+            .client_disconnect_downstream_bytes
+            .inc_by(bytes_from_upstream);
+    }
+}
+
 fn response_to_hyper<R>(
     response: HttpResponse,
     body: Option<R>,
     metrics: Arc<DownstreamMetrics>,
+    request_bytes: Arc<RequestByteCounts>,
 ) -> Result<Response<HyperBody>, ProxyError>
 where
     R: AsyncRead + Send + Sync + Unpin + 'static,
@@ -589,13 +694,23 @@ where
     let mut builder = Response::builder().status(response.status);
     let headers = builder.headers_mut().unwrap();
     *headers = response.headers;
+    let content_length = headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok());
     let body = match body {
         Some(body) => {
+            let response_metrics = Arc::new(ResponseBodyMetrics::new(
+                metrics,
+                request_bytes,
+                content_length,
+            ));
             let stream = ReaderStream::new(body);
             let stream = TrackedStream::new(stream, move |ev| match ev {
-                StreamEvent::Done(Ok(())) => nores(metrics.requests_completed.inc()),
-                StreamEvent::Done(Err(_)) => nores(metrics.requests_failed.inc()),
-                _ => {}
+                StreamEvent::Data(bytes) => response_metrics.record_body_bytes(bytes),
+                StreamEvent::Done(Ok(())) => response_metrics.mark_completed(),
+                StreamEvent::Done(Err(_)) => response_metrics.mark_failed(),
+                StreamEvent::DroppedBeforeDone => response_metrics.mark_client_disconnect(),
             });
             StreamBody::new(stream.map_ok(Frame::data)).boxed()
         }

--- a/src/downstream/metrics.rs
+++ b/src/downstream/metrics.rs
@@ -30,6 +30,8 @@ pub struct DownstreamMetrics {
     pub requests_completed: Counter,
     /// Requests that failed after being accepted (upstream or network error).
     pub requests_failed: Counter,
+    /// Requests whose downstream client stopped reading before the upstream response body finished.
+    pub client_disconnect_count: Counter,
 
     /// Number of QUIC connections opened toward upstream iroh nodes.
     pub iroh_connections_opened: Counter,
@@ -42,6 +44,10 @@ pub struct DownstreamMetrics {
     pub bytes_to_upstream: Counter,
     /// Bytes read from the upstream proxy (upstream ➜ downstream).
     pub bytes_from_upstream: Counter,
+    /// Bytes written to the upstream proxy before downstream client disconnects.
+    pub client_disconnect_upstream_bytes: Counter,
+    /// Bytes read from the upstream proxy before downstream client disconnects.
+    pub client_disconnect_downstream_bytes: Counter,
 }
 
 impl DownstreamMetrics {
@@ -53,6 +59,7 @@ impl DownstreamMetrics {
             .get()
             .saturating_sub(self.requests_completed.get())
             .saturating_sub(self.requests_failed.get())
+            .saturating_sub(self.client_disconnect_count.get())
     }
 
     /// Returns the total number of opened QUIC connections.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -127,6 +127,15 @@ async fn spawn_origin_server_echo_body(
     Ok((tcp_addr, AbortOnDropHandle::new(task)))
 }
 
+/// Spawns a simple HTTP origin server that streams a large response body slowly.
+async fn spawn_origin_server_streaming_body() -> Result<(SocketAddr, AbortOnDropHandle<()>)> {
+    let listener = TcpListener::bind("localhost:0").await?;
+    let tcp_addr = listener.local_addr()?;
+    debug!(%tcp_addr, "spawned streaming origin server");
+    let task = tokio::spawn(async move { origin_server::run_streaming_body(listener).await });
+    Ok((tcp_addr, AbortOnDropHandle::new(task)))
+}
+
 /// Spawns a simple TCP echo server.
 async fn spawn_echo_server() -> Result<(SocketAddr, AbortOnDropHandle<()>)> {
     let listener = TcpListener::bind("localhost:0").await?;
@@ -1692,14 +1701,20 @@ async fn test_uds_http2_reverse() -> Result<()> {
 }
 
 mod origin_server {
-    use std::{convert::Infallible, sync::Arc};
+    use std::{convert::Infallible, sync::Arc, time::Duration};
 
     use fastwebsockets::{FragmentCollector, Frame, OpCode, Payload, WebSocketError};
     use http::HeaderValue;
-    use http_body_util::{BodyExt, Empty, Full};
-    use hyper::{Request, Response, body::Bytes, server::conn::http1, service::service_fn};
+    use http_body_util::{BodyExt, Empty, Full, StreamBody};
+    use hyper::{
+        Request, Response,
+        body::{Bytes, Frame as BodyFrame},
+        server::conn::http1,
+        service::service_fn,
+    };
     use hyper_util::rt::TokioIo;
     use tokio::net::TcpListener;
+    use tokio_stream::wrappers::ReceiverStream;
     use tracing::debug;
 
     /// Returns "{label} {METHOD} {PATH}" as response body.
@@ -1754,6 +1769,42 @@ mod origin_server {
                         let response = format!("{} {} {}: {}", *label, method, path, body_str);
                         Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(response))))
                     }
+                };
+                let _ = http1::Builder::new()
+                    .serve_connection(io, service_fn(handler))
+                    .await;
+            });
+        }
+    }
+
+    /// Streams a large response body slowly so tests can disconnect mid-response.
+    pub(super) async fn run_streaming_body(listener: TcpListener) {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let io = TokioIo::new(stream);
+            tokio::task::spawn(async move {
+                let handler = move |_req: Request<hyper::body::Incoming>| async move {
+                    let (tx, rx) =
+                        tokio::sync::mpsc::channel::<Result<BodyFrame<Bytes>, Infallible>>(1);
+                    tokio::spawn(async move {
+                        for _ in 0..64 {
+                            let frame = BodyFrame::data(Bytes::from(vec![b'x'; 16 * 1024]));
+                            if tx.send(Ok(frame)).await.is_err() {
+                                break;
+                            }
+                            tokio::time::sleep(Duration::from_millis(10)).await;
+                        }
+                    });
+
+                    let body = StreamBody::new(ReceiverStream::new(rx)).boxed();
+                    let mut res = Response::new(body);
+                    res.headers_mut().insert(
+                        http::header::CONTENT_LENGTH,
+                        HeaderValue::from_str(&(64 * 16 * 1024).to_string()).unwrap(),
+                    );
+                    Ok::<_, Infallible>(res)
                 };
                 let _ = http1::Builder::new()
                     .serve_connection(io, service_fn(handler))
@@ -1903,6 +1954,7 @@ mod metrics {
         assert_eq!(downstream_metrics.requests_accepted.get(), 1);
         assert_eq!(downstream_metrics.requests_accepted_h1.get(), 1);
         assert_eq!(downstream_metrics.requests_completed.get(), 1);
+        assert_eq!(downstream_metrics.client_disconnect_count.get(), 0);
         assert_eq!(downstream_metrics.requests_denied.get(), 0);
         assert!(downstream_metrics.bytes_to_upstream.get() > 0);
         assert!(downstream_metrics.bytes_from_upstream.get() > 0);
@@ -1935,6 +1987,60 @@ mod metrics {
 
     #[tokio::test]
     #[traced_test]
+    async fn http_metrics_do_not_complete_when_client_drops_response_body() -> Result {
+        let (origin_addr, origin_task) = spawn_origin_server_streaming_body().await?;
+        let (upstream_router, upstream_id, _upstream_metrics) =
+            spawn_upstream_proxy_with_metrics().await?;
+        let mode = ProxyMode::Http(HttpProxyOpts::new(StaticForwardProxy(upstream_id)));
+        let (proxy_addr, _, downstream_metrics, proxy_task) =
+            spawn_downstream_proxy_with_metrics(mode).await?;
+
+        let mut stream = TcpStream::connect(proxy_addr).await?;
+        let req = format!(
+            "GET http://{origin_addr}/stream HTTP/1.1\r\n\
+             Host: {origin_addr}\r\n\
+             Connection: close\r\n\r\n"
+        );
+        stream.write_all(req.as_bytes()).await?;
+
+        let mut response_buf = vec![0u8; 4096];
+        let bytes_read = stream.read(&mut response_buf).await?;
+        assert!(bytes_read > 0);
+        drop(stream);
+
+        for _ in 0..100 {
+            if downstream_metrics.active_requests() == 0
+                && downstream_metrics.requests_accepted.get() == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(downstream_metrics.requests_accepted.get(), 1);
+        assert_eq!(downstream_metrics.active_requests(), 0);
+        assert_eq!(downstream_metrics.requests_completed.get(), 0);
+        assert_eq!(downstream_metrics.requests_failed.get(), 0);
+        assert_eq!(downstream_metrics.client_disconnect_count.get(), 1);
+        assert_eq!(
+            downstream_metrics.client_disconnect_upstream_bytes.get(),
+            downstream_metrics.bytes_to_upstream.get()
+        );
+        assert_eq!(
+            downstream_metrics.client_disconnect_downstream_bytes.get(),
+            downstream_metrics.bytes_from_upstream.get()
+        );
+        assert!(downstream_metrics.client_disconnect_upstream_bytes.get() > 0);
+        assert!(downstream_metrics.client_disconnect_downstream_bytes.get() > 0);
+
+        drop(origin_task);
+        drop(proxy_task);
+        upstream_router.shutdown().await.anyerr()?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
     async fn http_metrics_deny_behavior() -> Result {
         let mode = ProxyMode::Http(HttpProxyOpts::new(RejectAll));
         let (proxy_addr, _, metrics, proxy_task) =
@@ -1953,6 +2059,7 @@ mod metrics {
         assert_eq!(metrics.requests_denied.get(), 1);
         assert_eq!(metrics.requests_completed.get(), 0);
         assert_eq!(metrics.requests_failed.get(), 0);
+        assert_eq!(metrics.client_disconnect_count.get(), 0);
         assert_eq!(metrics.active_requests(), 0);
 
         drop(proxy_task);

--- a/src/util.rs
+++ b/src/util.rs
@@ -82,6 +82,7 @@ where
 pub enum StreamEvent<'a> {
     Data(u64),
     Done(Result<(), &'a io::Error>),
+    DroppedBeforeDone,
 }
 
 impl<S, F> TrackedStream<S, F>
@@ -104,7 +105,7 @@ where
 {
     fn drop(self: Pin<&mut Self>) {
         if let Some(f) = self.project().on_event.take() {
-            f(StreamEvent::Done(Ok(())));
+            f(StreamEvent::DroppedBeforeDone);
         }
     }
 }


### PR DESCRIPTION
  ## Summary

  Adds downstream proxy metrics for local clients that disconnect before the upstream response body finishes:

  - `client_disconnect_count`
  - `client_disconnect_upstream_bytes`
  - `client_disconnect_downstream_bytes`

  This keeps client disconnects distinct from successful completions and upstream/network failures.

  ## Motivation

  Before this change, dropping a downstream HTTP client mid-response could be counted as a completed request because `TrackedStream` treated stream drop as `Done(Ok(()))`.

  Example failure mode:

  1. Downstream proxy accepts an HTTP request.
  2. Upstream begins returning a large response body.
  3. Local HTTP client reads only part of the response and closes the socket.
  4. The proxy sees a body stream drop before EOF.
  5. Metrics previously reported `requests_completed += 1`.

  That makes cancellation/discard behavior invisible to consumers of proxy metrics.

  ## Implementation

  - Adds a `DroppedBeforeDone` stream event.
  - Tracks per-request bytes written to and read from the upstream proxy.
  - Marks a request as a client disconnect when the downstream response body stream is dropped before completion.
  - Keeps existing completed and failed counters for their existing meanings.
  - Updates `active_requests()` to subtract disconnects as terminal request outcomes.

  The byte counters are named for what they measure:
  - `client_disconnect_upstream_bytes`: bytes written to the upstream proxy before the local client disconnect.
  - `client_disconnect_downstream_bytes`: bytes read from the upstream proxy before the local client disconnect.

  They do not claim to measure wasted wire bytes.

  ## Tests

  Added an integration-style test that runs the real downstream proxy, upstream proxy, streaming origin server, and raw TCP client. The client reads part of a
  large response and then disconnects.

  The test verifies:

  - request is accepted
  - request is no longer active after disconnect
  - request is not counted as completed
  - request is not counted as failed
  - disconnect count increments
  - disconnect byte counters match the actual per-proxy byte counters

  Also extended existing metrics tests to assert normal completed and denied requests do not increment disconnect metrics.

  ## Validation

  Ran:

  ```sh
  cargo test http_metrics_do_not_complete_when_client_drops_response_body -- --nocapture
  cargo test metrics:: -- --nocapture
  cargo test
  cargo fmt --all --check -- --config unstable_features=true --config
  imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true
  cargo clippy --all-targets
  ```
  Results:

  - focused disconnect test passed
  - metrics tests passed
  - full test suite passed: 42 tests
  - rustfmt check passed
  - clippy passed with existing warnings

⚠️  cargo clippy --all-targets -- -D warnings currently fails on pre-existing warnings outside this change.